### PR TITLE
Variety of code cleanup

### DIFF
--- a/lib/splunkdriver.js
+++ b/lib/splunkdriver.js
@@ -25,35 +25,35 @@
  * main statsd distribution for guidance. (https://github.com/etsy/statsd) 
  */
 
-var request = require('request');
+const request = require('request');
 
 // this will be instantiated to the logger
-var l;
+let l;
 
-var flushInterval;
-var flush_counts;
-var splunkHost;
-var splunkPort;
-var useSSL;
-var strictSSL;
-var splunkToken;
-var counterLabel;
-var timerLabel;
-var gaugeLabel;
-var setLabel;
-var host;
-var source;
-var sourcetype;
-var index;
-var prefixStats;
+let flushCounts;
+let splunkHost;
+let splunkPort;
+let useSSL;
+let strictSSL;
+let splunkToken;
+let counterLabel;
+let timerLabel;
+let gaugeLabel;
+let setLabel;
+let host;
+let source;
+let sourcetype;
+let index;
+let prefixStats;
 
-var splunkStats = {};
+const splunkStats = {};
 
-function Stats() {
-  var s = this;
-  this.metrics = [];  
-  this.add = function(metricType, key, metrics, ts) {
-    metric = {};
+class Stats {
+  constructor() {
+    this.metrics = [];
+  }
+  add(metricType, key, metrics, ts) {
+    var metric = {};
     metric.event = metrics;
     metric.event.metricType = metricType;
     metric.event.metricName = key;
@@ -62,136 +62,129 @@ function Stats() {
     if (source) metric.source = source;
     if (sourcetype) metric.sourcetype = sourcetype;
     if (index) metric.index = index;
-    s.metrics.push(metric);
+    this.metrics.push(metric);
   }
-
-  // turn a collection of metrics into a valid Splunk HEC event.
-  // We assume batching
-  this.to_text = function() {
-    var output = "";
-    s.metrics.map(function(m) {
-      output += JSON.stringify(m);
-    });
-    return output;
+  toText() {
+    return this.metrics.map((m) => JSON.stringify(m)).join('');
   }
 }
 
-var hec_output = function splunk_hec_output(stats) {
-
-  var ts = Math.round(Date.now() / 1000);
+function hecOutput(stats) {
+  const ts = Math.round(Date.now() / 1000);
   stats.add(prefixStats, 'splunkStats', splunkStats, ts);
-  var stats_payload = stats.to_text();
-  if (splunkHost) {
-    var url = '';
-    url += useSSL ? 'https://' : 'http://';
-    url += splunkHost;
-    url += ':' + splunkPort;
-    url += '/services/collector/event';
-    var options = {
-      url: url,
-      strictSSL: strictSSL,
-      method: 'POST',
-      headers: {
-        'Authorization': 'Splunk '+ splunkToken
-      },
-      body: stats_payload
-    };
+  const statsPayload = stats.toText();
+  let splunkUrl = new URL(`http://${splunkHost}:${splunkPort}`);
+  if (useSSL) splunkUrl.protocol = 'https';
+  splunkUrl.pathname = '/services/collector/event';
+  const options = {
+    url: splunkUrl.href,
+    strictSSL: strictSSL,
+    method: 'POST',
+    headers: {
+      Authorization: `Splunk ${splunkToken}`,
+    },
+    body: statsPayload
+  };
 
-    function callback(error, response, body) {
-      if (error) {
-        splunkStats.last_exception = Math.round(Date.now() / 1000);
-        l.log(error);
-      }
-
+  function callback(error, _response, _body) {
+    if (error) {
+      splunkStats.last_exception = Math.round(Date.now() / 1000);
+      l.log(error);
     }
-    var starttime = Date.now();
-    request(options, callback);
-
-    splunkStats.flush_time = (Date.now() - starttime);
-    splunkStats.flush_length = stats_payload.length;
-    splunkStats.last_flush = Math.round(Date.now() / 1000);
 
   }
+  const starttime = Date.now();
+  request(options, callback);
+
+  splunkStats.flush_time = (Date.now() - starttime);
+  splunkStats.flush_length = statsPayload.length;
+  splunkStats.last_flush = Math.round(Date.now() / 1000);
 }
 
-var flush_stats = function splunk_flush(ts, metrics) {
-  var starttime = Date.now();
-  var numStats = 0;
-  var key;
-  var timer_data_key;
-  var counters = metrics.counters;
-  var gauges = metrics.gauges;
-  var timers = metrics.timers;
-  var sets = metrics.sets;
-  var counter_rates = metrics.counter_rates;
-  var timer_data = metrics.timer_data;
-  var statsd_metrics = metrics.statsd_metrics;
+function flushStats(ts, metrics) {
+  const starttime = Date.now();
+  let numStats = 0;
+  const counters = metrics.counters;
+  const gauges = metrics.gauges;
+  const sets = metrics.sets;
+  const counterRates = metrics.counter_rates;
+  const timerData = metrics.timer_data;
+  const statsdMetrics = metrics.statsd_metrics;
+  /* unused metrics fields:
+   * metrics.timers - raw timer data
+   * metrics.timer_counters - number of datapoints in each timer. (Equivalent to timer_data[timer].count)
+   * metrics.pct_threshold - equivalent to config.percentThreshold of timers
+   */
 
-  var stats = new Stats();
+  const stats = new Stats();
 
-  for (key in counters) {
-    metric = {};
-    metric.rate = counter_rates[key];
-    if (flush_counts) metric.count = counters[key];
-    stats.add(counterLabel, key, metric, ts);
+  for (const counter in counters) {
+    const metric = {
+      rate: counterRates[counter]
+    };
+    if (flushCounts) metric.count = counters[counter];
+    stats.add(counterLabel, counter, metric, ts);
     numStats += 1;
   }
 
-  for (key in timer_data) {
-    stats.add(timerLabel, key, timer_data[key], ts);
+  for (const timer in timerData) {
+    stats.add(timerLabel, timer, timerData[timer], ts);
     numStats += 1;
   }
-
-  for (key in gauges) {
-    metric = {};
-    metric.value = gauges[key];
-    stats.add(gaugeLabel, key, metric, ts);
+  
+  for (const gauge in gauges) {
+    const metric = {
+      value: gauges[gauge]
+    };
+    stats.add(gaugeLabel, gauge, metric, ts);
     numStats += 1;
   }
-
-  for (key in sets) {
-    metric = {};
-    metric.count = sets[key].size();
-    stats.add(setLabel, key, metric, ts);
+ 
+  for (const set in sets) {
+    const metric = {
+      count: sets[set].size(),
+    };
+    stats.add(setLabel, set, metric, ts);
     numStats += 1;
   }
 
   splunkStats.numStats = numStats;
   splunkStats.calculationTime = (Date.now() - starttime);
-  statsd = {}
-  for (key in statsd_metrics) {
-    statsd[key] = statsd_metrics[key];
+  
+  if (statsdMetrics) {
+    stats.add(prefixStats, 'statsd', statsdMetrics, ts);
   }
-  stats.add(prefixStats, 'statsd', statsd, ts);
-  hec_output(stats);
+  
+  hecOutput(stats);
 }
 
-exports.init = function splunk_init(startup_time, config, events, logger) {
+function splunkInit(startup_time, config, events, logger) {
   l = logger;
-  splunkHost = config.splunk.splunkHost || '127.0.0.1';
-  splunkPort = config.splunk.splunkPort || 8088;
-  useSSL = typeof(config.splunk.useSSL) === 'undefined' ? true : config.splunk.useSSL;
-  strictSSL = typeof(config.splunk.strictSSL) === 'undefined' ? true : config.splunk.strictSSL;
+  splunkHost = config.splunk.splunkHost ?? '127.0.0.1';
+  splunkPort = config.splunk.splunkPort ?? 8088;
+  useSSL = config.splunk.useSSL ?? true;
+  strictSSL = config.splunk.strictSSL ?? true;
   splunkToken = config.splunk.splunkToken;
-  counterLabel = config.splunk.counterLabel || 'counter';
-  timerLabel = config.splunk.timerLabel || 'timer';
-  gaugeLabel = config.splunk.gaugeLabel || 'gauge';
-  setLabel = config.splunk.setLabel || 'set';
-  source = config.splunk.source || 'statsd';
-  sourcetype = config.splunk.sourcetype || '_json';
+  counterLabel = config.splunk.counterLabel ?? 'counter';
+  timerLabel = config.splunk.timerLabel ?? 'timer';
+  gaugeLabel = config.splunk.gaugeLabel ?? 'gauge';
+  setLabel = config.splunk.setLabel ?? 'set';
+  source = config.splunk.source ?? 'statsd';
+  sourcetype = config.splunk.sourcetype ?? '_json';
   host = config.splunk.host;
   index = config.splunk.index;
-  flushInterval = config.flushInterval;
-  flush_counts = typeof(config.flush_counts) === "undefined" ? true : config.flush_counts;
-  prefixStats = config.prefixStats || 'statsd';
+  flushCounts = config.flush_counts ?? true;
+  prefixStats = config.prefixStats ?? 'statsd';
 
   splunkStats.last_flush = startup_time;
   splunkStats.last_exception = startup_time;
   splunkStats.flush_time = 0;
   splunkStats.flush_length = 0;
 
-  events.on('flush', flush_stats);
+  events.on('flush', flushStats);
   //events.on('status', backend_status);
 
   return true;
 }
+
+exports.init = splunkInit;

--- a/lib/splunkdriver.js
+++ b/lib/splunkdriver.js
@@ -160,21 +160,21 @@ function flushStats(ts, metrics) {
 
 function splunkInit(startup_time, config, events, logger) {
   l = logger;
-  splunkHost = config.splunk.splunkHost ?? '127.0.0.1';
-  splunkPort = config.splunk.splunkPort ?? 8088;
-  useSSL = config.splunk.useSSL ?? true;
-  strictSSL = config.splunk.strictSSL ?? true;
+  splunkHost = config.splunk.splunkHost || '127.0.0.1';
+  splunkPort = config.splunk.splunkPort || 8088;
+  useSSL = typeof(config.splunk.useSSL) === 'undefined' ? true : config.splunk.useSSL;
+  strictSSL = typeof(config.splunk.strictSSL) === 'undefined' ? true : config.splunk.strictSSL;
   splunkToken = config.splunk.splunkToken;
-  counterLabel = config.splunk.counterLabel ?? 'counter';
-  timerLabel = config.splunk.timerLabel ?? 'timer';
-  gaugeLabel = config.splunk.gaugeLabel ?? 'gauge';
-  setLabel = config.splunk.setLabel ?? 'set';
-  source = config.splunk.source ?? 'statsd';
-  sourcetype = config.splunk.sourcetype ?? '_json';
+  counterLabel = config.splunk.counterLabel || 'counter';
+  timerLabel = config.splunk.timerLabel || 'timer';
+  gaugeLabel = config.splunk.gaugeLabel || 'gauge';
+  setLabel = config.splunk.setLabel || 'set';
+  source = config.splunk.source || 'statsd';
+  sourcetype = config.splunk.sourcetype || '_json';
   host = config.splunk.host;
   index = config.splunk.index;
-  flushCounts = config.flush_counts ?? true;
-  prefixStats = config.prefixStats ?? 'statsd';
+  flushCounts = typeof(config.flush_counts) === "undefined" ? true : config.flush_counts;
+  prefixStats = config.prefixStats || 'statsd';
 
   splunkStats.last_flush = startup_time;
   splunkStats.last_exception = startup_time;

--- a/lib/splunkdriver.test.js
+++ b/lib/splunkdriver.test.js
@@ -6,8 +6,6 @@ jest.mock('request');
 
 const emitter = new events.EventEmitter()
 
-Date.now = jest.fn(() => 1487076708000) //14.02.2017
-
 test('successful init', () => {
     const config = {
         splunk: {
@@ -84,7 +82,7 @@ test('flush with timers', () => {
         count: 3,
         count_ps: 30,
         sum: 600,
-        sum_squares: 100 * 100 + 200 * 200 + 300 * 300,
+        sum_squares: 140000,
         mean: 200,
         median: 200,
     };
@@ -111,29 +109,27 @@ function expectedMetric(metric) {
     return expect.stringContaining(JSON.stringify(metric));
 }
 
-function expectedSet(name, count, type = "set") {
+function expectedSet(metricName, count, metricType = "set") {
     return expectedMetric({
-            "count": count,
-            "metricType": type,
-            "metricName": name,
-        }
-    );
+        count,
+        metricType,
+        metricName,
+    });
 }
 
-function expectedCounter(name, count, rate, type = "counter") {
+function expectedCounter(metricName, count, rate, metricType = "counter") {
     return expectedMetric({
-            "rate": rate,
-            "count": count,
-            "metricType": type,
-            "metricName": name,
-        }
-    );
+        rate,
+        count,
+        metricType,
+        metricName,
+    });
 }
 
-function expectedGauge(name, value, type = "gauge") {
+function expectedGauge(metricName, value, metricType = "gauge") {
     return expectedMetric({
-        "value": value,
-        "metricType": type,
-        "metricName": name,
+        value,
+        metricType,
+        metricName,
     });
 }


### PR DESCRIPTION
* replace `var` with `const`/`let` as appropriate
* replace function expressions with function declarations
* use ES6 style classes
* make naming more consistent. (snake_case is only used in output)
* use nullish coalescing for config defaults
* remove unused variables